### PR TITLE
Set window name as tab reference for geoportail

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,8 @@ export default function plugin(
       return {
         pathTo2dGeoportal: config.pathTo2dGeoportal,
         tabId: config.tabId,
+        pathToPrintPortal: config.pathToPrintPortal,
+        tabIdPrint: config.tabIdPrint
       };
     },
     /**
@@ -177,6 +179,8 @@ export default function plugin(
       return {
         pathTo2dGeoportal: config.pathTo2dGeoportal,
         tabId: config.tabId,
+        pathToPrintPortal: config.pathToPrintPortal,
+        tabIdPrint: config.tabIdPrint
       };
     },
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,7 @@ export default function plugin(
     },
     // eslint-disable-next-line  @typescript-eslint/no-unused-vars
     initialize(vcsUiApp: VcsUiApp, pluginState?: PluginState): Promise<void> {
+      window.name = 'lux3d'; // set window name as tab reference for geoportail
       initializeBack2DAction(config, vcsUiApp);
       initializePrintAction(config, vcsUiApp);
 
@@ -169,7 +170,7 @@ export default function plugin(
         pathTo2dGeoportal: config.pathTo2dGeoportal,
         tabId: config.tabId,
         pathToPrintPortal: config.pathToPrintPortal,
-        tabIdPrint: config.tabIdPrint
+        tabIdPrint: config.tabIdPrint,
       };
     },
     /**
@@ -180,7 +181,7 @@ export default function plugin(
         pathTo2dGeoportal: config.pathTo2dGeoportal,
         tabId: config.tabId,
         pathToPrintPortal: config.pathToPrintPortal,
-        tabIdPrint: config.tabIdPrint
+        tabIdPrint: config.tabIdPrint,
       };
     },
     /**


### PR DESCRIPTION
This PR ensures that the geoportail has the tab reference from the beginning.