### PR TITLE
Use export icon instead of upload icon

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ function initializePrintAction(config: PluginConfig, vcsUiApp: VcsUiApp): void {
   const action = {
     name: '3DPrint',
     title: 'linkTo3DPrint.title',
-    icon: '$vcsUpload',
+    icon: '$vcsExport',
     callback: async (): Promise<void> => {
       const state = await vcsUiApp.getState(true);
 


### PR DESCRIPTION
This PR changes the 3d print icon.

<img width="271" height="95" alt="image" src="https://github.com/user-attachments/assets/ac7f9d70-2631-4571-afbe-170eb5733367" />

